### PR TITLE
Optimization of triangle removal

### DIFF
--- a/DelaunayVoronoi/Delaunay.cs
+++ b/DelaunayVoronoi/Delaunay.cs
@@ -52,8 +52,8 @@ namespace DelaunayVoronoi
                     {
                         vertex.AdjacentTriangles.Remove(triangle);
                     }
+                    triangulation.Remove(triangle);
                 }
-                triangulation.RemoveWhere(o => badTriangles.Contains(o));
 
                 foreach (var edge in polygon.Where(possibleEdge => possibleEdge.Point1 != point && possibleEdge.Point2 != point))
                 {


### PR DESCRIPTION
This change makes the process of removing bad triangles from all triangles faster for larger sets of points (for 10000 points it increases the overall performance of the DelaunayTriangulator.BowyerWatson function by about 20%)